### PR TITLE
Fix pg18 CI failures: skip tools/osmium build for trixie in update.sh

### DIFF
--- a/18-3.6-3.7/extra/Dockerfile
+++ b/18-3.6-3.7/extra/Dockerfile
@@ -24,12 +24,12 @@ RUN apt update \
  && cmake .. \
  && make \
  && make install \
- && cd ../tools/osmium/ \
- && mkdir build \
- && cd build \
- && cmake .. \
- && make \
- && make install \
+#  && cd ../tools/osmium/ \
+#  && mkdir build \
+#  && cd build \
+#  && cmake .. \
+#  && make \
+#  && make install \
  && cd /usr/local/src \
  && rm -rf ./* \
  && apt purge -y --autoremove \

--- a/18-3.6-3.8/extra/Dockerfile
+++ b/18-3.6-3.8/extra/Dockerfile
@@ -24,12 +24,12 @@ RUN apt update \
  && cmake .. \
  && make \
  && make install \
- && cd ../tools/osmium/ \
- && mkdir build \
- && cd build \
- && cmake .. \
- && make \
- && make install \
+#  && cd ../tools/osmium/ \
+#  && mkdir build \
+#  && cd build \
+#  && cmake .. \
+#  && make \
+#  && make install \
  && cd /usr/local/src \
  && rm -rf ./* \
  && apt purge -y --autoremove \

--- a/18-3.6-4.0/extra/Dockerfile
+++ b/18-3.6-4.0/extra/Dockerfile
@@ -24,12 +24,12 @@ RUN apt update \
  && cmake .. \
  && make \
  && make install \
- && cd ../tools/osmium/ \
- && mkdir build \
- && cd build \
- && cmake .. \
- && make \
- && make install \
+#  && cd ../tools/osmium/ \
+#  && mkdir build \
+#  && cd build \
+#  && cmake .. \
+#  && make \
+#  && make install \
  && cd /usr/local/src \
  && rm -rf ./* \
  && apt purge -y --autoremove \

--- a/18-3.6-develop/extra/Dockerfile
+++ b/18-3.6-develop/extra/Dockerfile
@@ -24,12 +24,12 @@ RUN apt update \
  && cmake .. \
  && make \
  && make install \
- && cd ../tools/osmium/ \
- && mkdir build \
- && cd build \
- && cmake .. \
- && make \
- && make install \
+#  && cd ../tools/osmium/ \
+#  && mkdir build \
+#  && cd build \
+#  && cmake .. \
+#  && make \
+#  && make install \
  && cd /usr/local/src \
  && rm -rf ./* \
  && apt purge -y --autoremove \

--- a/18-3.6-main/extra/Dockerfile
+++ b/18-3.6-main/extra/Dockerfile
@@ -24,12 +24,12 @@ RUN apt update \
  && cmake .. \
  && make \
  && make install \
- && cd ../tools/osmium/ \
- && mkdir build \
- && cd build \
- && cmake .. \
- && make \
- && make install \
+#  && cd ../tools/osmium/ \
+#  && mkdir build \
+#  && cd build \
+#  && cmake .. \
+#  && make \
+#  && make install \
  && cd /usr/local/src \
  && rm -rf ./* \
  && apt purge -y --autoremove \

--- a/update.sh
+++ b/update.sh
@@ -96,6 +96,11 @@ for version in "${versions[@]}"; do
         sed -i 's/%%PG_MAJOR%%/'"$postgresVersion"'/g; s/%%POSTGIS_VERSION%%/'"$postgisVersion"'/g; s/%%PGROUTING_VERSION%%/'"$pgroutingVersion"'/g;' "$version/docker-compose.yml"
         mv "$version/extra/Dockerfile.template" "$version/extra/Dockerfile"
         sed -i 's/%%PG_MAJOR%%/'"$postgresVersion"'/g; s/%%POSTGIS_VERSION%%/'"$postgisVersion"'/g; s/%%PGROUTING_VERSION%%/'"$pgroutingVersion"'/g; s/%%PQXX_VERSION%%/'"$pqxxVersion"'/g;' "$version/extra/Dockerfile"
+        # libosmium2-dev on Trixie has incompatible C++ API changes; skip tools/osmium build temporarily
+        # See: https://github.com/pgRouting/osm2pgrouting/issues/323
+        if [ "$suite" = "trixie" ]; then
+            sed -i '/\&\& cd \.\.\/tools\/osmium\//,/\&\& make install/ s/^ \+\&\& /#  \&\& /' "$version/extra/Dockerfile"
+        fi
         echo "$postgresVersion-$postgisVersion-$pgroutingVersion" > "$version/version.txt"
     )
 done


### PR DESCRIPTION
## Problem

All `18-3.6-*` extra image builds have been failing since PR #75 was merged.

The root cause is a missing template-level fix. PR #75 commit `9fe515a`
manually commented out the `tools/osmium` build lines in each
`18-3.6-*/extra/Dockerfile`, but did **not** update `update.sh` (or
`extra/Dockerfile.template`). As a result, the subsequent nightly
"Update hashes and versions" PR (#76) ran `make update`, which
regenerated those files from the unchanged template — silently reverting
the comments and re-introducing the build failure.

The underlying incompatibility: `libosmium2-dev` on Debian Trixie (used
by pg18 images) has C++ API changes that break the `tools/osmium` build
in osm2pgrouting 3.0.0.
See: https://github.com/pgRouting/osm2pgrouting/issues/323

## Fix

Add a post-generation step in `update.sh` that comments out the
`tools/osmium` build block whenever the target Debian suite is `trixie`.
This ensures `make update` produces the correct output and the fix
survives future hash-update regenerations.

Also re-apply the comment-out to the five currently broken generated
files (`18-3.6-{3.7,3.8,4.0,develop,main}/extra/Dockerfile`).

## Changes

- `update.sh`: after rendering `extra/Dockerfile`, comment out the
  `tools/osmium` build block when `$suite = "trixie"`
- `18-3.6-{3.7,3.8,4.0,develop,main}/extra/Dockerfile`: re-generated
  with the osmium build skipped